### PR TITLE
TST: switch all jobs to Python 3.13

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -19,23 +19,23 @@ jobs:
     with:
       submodules: false
       envs: |
-        - linux: py311-asdf_astropy
-        - linux: py311-asdf_astropy-dev
-        - linux: py311-astropy_healpix
-        - linux: py311-astropy_healpix-dev
-        - linux: py311-astroquery
-        - linux: py311-astroquery-dev
-        - linux: py311-ccdproc
-        - linux: py311-ccdproc-dev
-        - linux: py311-photutils
-        - linux: py311-photutils-dev
-        - linux: py311-regions
-        - linux: py311-regions-dev
-        - linux: py311-reproject
-        - linux: py311-reproject-dev
-        - linux: py311-specreduce
-        - linux: py311-specreduce-dev
-        - linux: py311-specutils
-        - linux: py311-specutils-dev
-        - linux: py311-sunpy
-        - linux: py311-sunpy-dev
+        - linux: py313-asdf_astropy
+        - linux: py313-asdf_astropy-dev
+        - linux: py313-astropy_healpix
+        - linux: py313-astropy_healpix-dev
+        - linux: py313-astroquery
+        - linux: py313-astroquery-dev
+        - linux: py313-ccdproc
+        - linux: py313-ccdproc-dev
+        - linux: py313-photutils
+        - linux: py313-photutils-dev
+        - linux: py313-regions
+        - linux: py313-regions-dev
+        - linux: py313-reproject
+        - linux: py313-reproject-dev
+        - linux: py313-specreduce
+        - linux: py313-specreduce-dev
+        - linux: py313-specutils
+        - linux: py313-specutils-dev
+        - linux: py313-sunpy
+        - linux: py313-sunpy-dev

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     # These are widely used packages that have historically
     # had issues with some astropy releases, so we include them here
     # as regression testing.
-    py{39,310,311,312}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}{,-dev}
+    py{39,310,311,312,313}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}{,-dev}
 
 requires =
     setuptools >= 30.3.0


### PR DESCRIPTION
This is an experimental/explorative PR to survey compatibility with Python 3.13 downstream of the core lib. I intend to offer help where (and if) necessary.

Status:
- [x] meta: requiring`astropy[all]` in this CI is blocked by https://github.com/apache/arrow/issues/43519 (but can be worked around or maybe even removed as it doesn't seem needed for most packages)
- [ ] `astroquery` is blocked by [mocpy](https://github.com/cds-astro/mocpy/) https://github.com/cds-astro/mocpy/issues/179
- [ ] `ccdproc` has one very minor incompatibility with NumPy 2.0 (which is already patched on the dev branch), nothing to see here
- [ ] `reproject` may actually need something from `astropy[all]` that's not in `astropy[recommended]` (test collection fails with `E   ModuleNotFoundError: No module named 'gwcs'`)
- [x] `sunpy` has two distinct failure modes:
	- [x] `sunpy` 6.0.2 fails with `ModuleNotFoundError: No module named 'cgi'` (blocked by zeep, the patch was merged but never released https://github.com/mvantellingen/python-zeep/pull/1364)
	- [x] `sunpy-dev` fails to compile (surprising, since it's using Python's Limited API, and `uv build -p 3.13` works fine on my system)