### PR TITLE
TST: check future compatibility with CPython 3.15

### DIFF
--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -20,20 +20,20 @@ jobs:
       submodules: false
       envs: |
         - linux: py311-asdf_astropy
-        - linux: py311-asdf_astropy-dev
+        - linux: py315-asdf_astropy-dev
         - linux: py311-astropy_healpix
-        - linux: py311-astropy_healpix-dev
+        - linux: py315-astropy_healpix-dev
         - linux: py311-ccdproc
-        - linux: py311-ccdproc-dev
+        - linux: py315-ccdproc-dev
         - linux: py311-photutils
-        - linux: py311-photutils-dev
+        - linux: py315-photutils-dev
         - linux: py311-regions
-        - linux: py311-regions-dev
+        - linux: py315-regions-dev
         - linux: py311-reproject
-        - linux: py311-reproject-dev
+        - linux: py315-reproject-dev
         - linux: py311-specreduce
-        - linux: py311-specreduce-dev
+        - linux: py315-specreduce-dev
         - linux: py311-specutils
-        - linux: py311-specutils-dev
+        - linux: py315-specutils-dev
         - linux: py312-sunpy
-        - linux: py312-sunpy-dev
+        - linux: py315-sunpy-dev

--- a/.github/workflows/integration_testing.yml
+++ b/.github/workflows/integration_testing.yml
@@ -20,20 +20,20 @@ jobs:
       submodules: false
       envs: |
         - linux: py311-asdf_astropy
-        - linux: py315-asdf_astropy-dev
+        - linux: py314-asdf_astropy-dev
         - linux: py311-astropy_healpix
         - linux: py315-astropy_healpix-dev
         - linux: py311-ccdproc
-        - linux: py315-ccdproc-dev
+        - linux: py314-ccdproc-dev
         - linux: py311-photutils
-        - linux: py315-photutils-dev
+        - linux: py314-photutils-dev
         - linux: py311-regions
         - linux: py315-regions-dev
         - linux: py311-reproject
-        - linux: py315-reproject-dev
+        - linux: py314-reproject-dev
         - linux: py311-specreduce
-        - linux: py315-specreduce-dev
+        - linux: py314-specreduce-dev
         - linux: py311-specutils
-        - linux: py315-specutils-dev
+        - linux: py314-specutils-dev
         - linux: py312-sunpy
         - linux: py315-sunpy-dev

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     #astroquery-!dev,all-!dev: astroquery[test,all]
     #astroquery-dev,all-dev: astroquery[test,all] @ git+https://github.com/astropy/astroquery.git
 
-    # cp315 blocker: scikit-image
+    # cp315 blockers: scipy, scikit-image
     ccdproc,all: psutil
     ccdproc-!dev,all-!dev: ccdproc[test,all]
     ccdproc-dev,all-dev: ccdproc[test,all] @ git+https://github.com/astropy/ccdproc.git

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     # These are widely used packages that have historically
     # had issues with some astropy releases, so we include them here
     # as regression testing.
-    py{311,312,313,314}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}{,-dev}
+    py{311,312,313,314,315}-{all,asdf_astropy,astropy_healpix,astroquery,ccdproc,photutils,regions,reproject,specreduce,specutils,sunpy}{,-dev}
 
 [testenv]
 # Pass through the following environment variables which are needed for the CI

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ pip_pre = true
 # Note that we install all dependencies in all environments to catch any
 # side effects and make sure all test suites pass with all packages
 deps =
-    astropy[all,test]
+    astropy[test]
 
     asdf_astropy-!dev,all-!dev: asdf_astropy[test]
     asdf_astropy-dev,all-dev: asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ deps =
     specutils-!dev,all-!dev: specutils[all,test]
     specutils-dev,all-dev: specutils[all,test] @ git+https://github.com/astropy/specutils.git
 
+    # cp315 blocker: lxml
     sunpy-!dev,all-!dev: sunpy[tests,all]
     sunpy-dev,all-dev: sunpy[tests,all] @ git+https://github.com/sunpy/sunpy.git
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ pip_pre = true
 deps =
     astropy[test]
 
+    # cp315 blocker: scipy
     asdf_astropy-!dev,all-!dev: asdf_astropy[test]
     asdf_astropy-dev,all-dev: asdf_astropy[test] @ git+https://github.com/astropy/asdf-astropy.git
 
@@ -30,23 +31,28 @@ deps =
     #astroquery-!dev,all-!dev: astroquery[test,all]
     #astroquery-dev,all-dev: astroquery[test,all] @ git+https://github.com/astropy/astroquery.git
 
+    # cp315 blocker: scikit-image
     ccdproc,all: psutil
     ccdproc-!dev,all-!dev: ccdproc[test,all]
     ccdproc-dev,all-dev: ccdproc[test,all] @ git+https://github.com/astropy/ccdproc.git
 
+    # cp315 blocker: scipy
     photutils-!dev,all-!dev: photutils[test,all]
     photutils-dev,all-dev: photutils[test,all] @ git+https://github.com/astropy/photutils.git
 
     regions-!dev,all-!dev: regions[test,all]
     regions-dev,all-dev: regions[test,all] @ git+https://github.com/astropy/regions.git
 
+    # cp315 blocker: scipy
     reproject,all: gwcs
     reproject-!dev,all-!dev: reproject[test,all]
     reproject-dev,all-dev: reproject[test,all] @ git+https://github.com/astropy/reproject.git
 
+    # cp315 blocker: scipy
     specreduce-!dev,all-!dev: specreduce[test]
     specreduce-dev,all-dev: specreduce[test] @ git+https://github.com/astropy/specreduce.git
 
+    # cp315 blocker: scipy
     specutils-!dev,all-!dev: specutils[all,test]
     specutils-dev,all-dev: specutils[all,test] @ git+https://github.com/astropy/specutils.git
 


### PR DESCRIPTION
Astropy itself has abi3 wheels now, which means we should be able to test downstream packages with future versions of CPython without rebuilding it. Let's give it a try.