### PR TITLE
MNT: clarify an inline comment in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # We define an environment per package so that we can then run 'tox' on its own
 # and have all packages be tested even if some have failures.
 envlist =
-    # Coordinated packages, except for these:
+    # Check compatibility of Coordinated Packages. Additionally:
     #    sunpy
     # These are widely used packages that have historically
     # had issues with some astropy releases, so we include them here


### PR DESCRIPTION
The original comment is ambiguous: it could also read "sunpy is a coordinated package we don't test for"