### PR TITLE
TST: avoid collecting setup_package module for reproject

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ commands =
     ccdproc,all: pytest --pyargs ccdproc
     photutils,all: pytest --pyargs photutils
     regions,all: pytest --pyargs regions
-    reproject,all: pytest --pyargs reproject
+    reproject,all: pytest --pyargs reproject --ignore reproject/spherical_intersect/setup_package.py
     specreduce,all: pytest --pyargs specreduce
     specutils,all: pytest --pyargs specutils
     sunpy,all: pytest --pyargs sunpy -c sunpy_pytest.ini


### PR DESCRIPTION
Fix a problem I found in https://github.com/astropy/astropy-integration-testing/pull/43.

The problem was that this build-only module, which has a dependency on setuptools (not a runtime dependency) is collected from, as all modules, when doctest is enabled (and it always is, here). It used to pass silently in Python 3.11 and older because these versions shipped setuptools alongside the standard library, but 3.12 and newer don't. 

This build-only module has to ship as part of a source install, and setuptools has no good way (that I know of) of excluding files *just* from wheels. So, even though there's no good reason to include it in wheels, it's understandable that this is the current state of affairs.