### PR TITLE
DEP: declare uv as a python dependency instead of relying on a external install

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -84,16 +84,13 @@ jobs:
             uv-${{ runner.os }}-${{ matrix.variant }}-
             uv-${{ runner.os }}-
 
-      - name: Install astropy-integration
-        run: pip install .
-
       - name: Run ${{ matrix.variant }} variant on Python ${{ matrix.python }}
         env:
           # PR previews limit each package to the first 10 tests so the
           # matrix finishes in minutes; conftest.py at the repo root reads
           # this env var and truncates the collected items.
           PYTEST_LIMIT_N: ${{ github.event_name == 'pull_request' && '10' || '' }}
-        run: astropy-integration run --variant ${{ matrix.variant }} --python ${{ matrix.python }}
+        run: uv run astropy-integration run --variant ${{ matrix.variant }} --python ${{ matrix.python }}
 
       - name: Prune uv cache before save
         if: always()
@@ -120,9 +117,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install astropy-integration
-        run: pip install .
-
       - name: Download all variant results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -131,7 +125,7 @@ jobs:
           path: results/
 
       - name: Build dashboard
-        run: astropy-integration dashboard
+        run: uv run astropy-integration dashboard
 
       # PR path: upload index.html as a non-zipped artifact for the
       # in-browser preview (linked from a PR check by preview-link.yml).

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,16 +56,13 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      # This Python only runs the `astropy-integration` orchestrator CLI;
-      # the test venv for `matrix.python` is built separately by uv (see
-      # the `run` step below), so a fixed version is fine here.
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: '3.12'
-
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
+          # This Python only runs the `astropy-integration` orchestrator CLI;
+          # the test venv for `matrix.python` is built separately by uv (see
+          # the `run` step below), so a fixed version is fine here.
+          python-version: '3.12'
           # We manage the cache ourselves via actions/cache below; turning
           # off setup-uv's own caching avoids it saving a duplicate of the
           # same directory under its own key.
@@ -119,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           python-version: '3.12'
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Running locally
 
 ```bash
 pip install .
-# uv is required; see https://docs.astral.sh/uv/
 
 # Run one variant. Each variant takes 30-90 min depending on package count.
 astropy-integration run --variant stable

--- a/astropy_integration/run.py
+++ b/astropy_integration/run.py
@@ -34,6 +34,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 
+import uv
 from packaging.version import InvalidVersion, Version
 
 from . import config, status
@@ -170,12 +171,12 @@ def _resolver_conflict(stderr):
 
 def ensure_python(version):
     proc = subprocess.run(
-        ["uv", "python", "find", version], capture_output=True, text=True, timeout=60
+        [uv.find_uv_bin(), "python", "find", version], capture_output=True, text=True, timeout=60
     )
     if proc.returncode == 0:
         return proc.stdout.strip()
     inst = subprocess.run(
-        ["uv", "python", "install", version],
+        [uv.find_uv_bin(), "python", "install", version],
         capture_output=True,
         text=True,
         timeout=600,
@@ -183,7 +184,7 @@ def ensure_python(version):
     if inst.returncode != 0:
         sys.exit(f"uv python install {version}: {inst.stderr.strip()}")
     proc = subprocess.run(
-        ["uv", "python", "find", version], capture_output=True, text=True, timeout=60
+        [uv.find_uv_bin(), "python", "find", version], capture_output=True, text=True, timeout=60
     )
     if proc.returncode != 0:
         sys.exit(f"uv python find {version}: {proc.stderr.strip()}")
@@ -221,7 +222,7 @@ def _pkg_version(python, name):
 
 def _freeze(python):
     proc = subprocess.run(
-        ["uv", "pip", "freeze", "--python", python],
+        [uv.find_uv_bin(), "pip", "freeze", "--python", python],
         capture_output=True,
         text=True,
         timeout=60,
@@ -331,7 +332,7 @@ def run_variant(
         py_path = ensure_python(python_version)
         venv = os.path.join(tmpdir, "venv")
         venv_proc = subprocess.run(
-            ["uv", "venv", venv, "-p", py_path, "-q"],
+            [uv.find_uv_bin(), "venv", venv, "-p", py_path, "-q"],
             capture_output=True,
             text=True,
             timeout=120,
@@ -343,7 +344,7 @@ def run_variant(
         result["python_version"] = _venv_python_version(python)
         constraints_path = os.path.join(tmpdir, "no-downgrade-constraints.txt")
 
-        common = ["uv", "pip", "install", "--python", python, "-q"]
+        common = [uv.find_uv_bin(), "pip", "install", "--python", python, "-q"]
         for url in core_spec["extra_index_urls"]:
             common += ["--extra-index-url", url]
         common += [f"--prerelease={core_spec['prerelease_strategy']}"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "jinja2",
     "packaging",
     "pyyaml",
+    "uv>=0.11.16",
 ]
 
 [project.scripts]


### PR DESCRIPTION
A couple follow ups to #44 I found while reviewing the PR post-merge
